### PR TITLE
Minor changes to the units/description of rt_diabatic_tend

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1722,7 +1722,7 @@
                 <var name="tend_theta" name_in_code="theta_m" type="real" dimensions="nVertLevels nCells Time" units="kg K m^{-3} s^{-1}"
                      description="tendency of coupled potential temperature rho*theta_m/zz from dynamics and physics, updated each RK step"/>
 
-                <var name="rt_diabatic_tend" type="real" dimensions="nVertLevels nCells Time" units="kg K s^{-1}"
+                <var name="rt_diabatic_tend" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
                      description="Tendency of coupled potential temperature from microphysics"/>
 
                 <var name="euler_tend_u" name_in_code="u_euler" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"


### PR DESCRIPTION
I believe the original units listed for rt_diabatic_tend (kg K s^{-1}) are incorrect and should just be K s^{-1} based on how this quantity is used in the model. I also modified the description to specify that this tendency comes from the microphysics scheme

The title above should be a 1 line short summary of the pull request (i.e. what the project the PR represents is intended to do).

Enter a description of this PR. This should include why this PR was created, and what it does.

Testing and relations to other Pull Requests should be added as subsequent comments.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

