### PR TITLE
Initialize tend_u_phys as zero

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -182,6 +182,8 @@
  tend_rho_physics(:,:) = 0._RKIND       ! NB: rho tendency is not currently supplied by physics, but this
                                         !     field may be later filled with IAU or other tendencies
 
+ tend_u_phys(:,:) = 0._RKIND            
+ 
  !
  ! In case some variables are not allocated due to their associated packages,
  ! we need to make their pointers associated here to avoid triggering run-time


### PR DESCRIPTION
I've added code to initialize and reset tend_u_phys as 0._RKIND during each time step. Otherwise, these tendency values accumulate over successive time steps, which impacts the PV budget calculation in pv_diagnostics.F
